### PR TITLE
Fix link to FRDR geodisy site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All of the software you need will be free and open source (FOSS). The Geodisy mi
 3. [Geoblacklight](https://geoblacklight.org) to allow users to search
 
 ### When will it be available?
-**Geodisy** is available now. See it in action at [geo.frdr.ca](https://geo.frdr.ca)
+**Geodisy** is available now. See it in action at [geo.frdr-dfdr.ca](https://geo.frdr-dfdr.ca/)
 
 ### Where can I find documentation?
 **Geodisy** documentation is available in our [Github repository](https://github.com/ubc-library/geodisy/blob/master/Documentation/index.md)


### PR DESCRIPTION
Hello geodisy team, I noticed the link to the [FRDR geodisy site](https://geo.frdr-dfdr.ca/) was broken in the README, so I replaced it with the correct link.